### PR TITLE
Improves container error message for easier debugging

### DIFF
--- a/rce-core/rce/container.py
+++ b/rce-core/rce/container.py
@@ -138,12 +138,15 @@ class RCEContainer(Referenceable):
 
         if os.path.isdir(confDir):
             raise ValueError('There is already a configuration directory for '
-                             "'{0}'.".format(name))
+                             "'{0}' \n Please remove it manually if the engine "
+                             'did not shut down correctly on last execution and '
+                             'you are sure it is not in use. \n dir: {1}.'.format(name, confDir))
 
         if os.path.isdir(dataDir):
             raise ValueError('There is already a data directory for '
-                             "'{0}'.".format(name))
-
+                             "'{0}' \n Please remove it manually if the engine "
+                             'did not shut down correctly on last execution and '
+                             'you are sure it is not in use. \n dir: {1}.'.format(name, dataDir))
         os.mkdir(confDir)
         os.mkdir(dataDir)
 


### PR DESCRIPTION
In case the engine is not shut down correctly, config and data
container folders are left in their directories, making it impossible to
execute the same code again after a problematic exit. The new error
message containes the path to the folder where the container
directories reside.

In order to prevent people deleting directories that are still in use,
 a short informative message is also provided.

This addresses but does not solve issue IDSCETHZurich/rce#39
